### PR TITLE
Add head ability

### DIFF
--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -11,13 +11,18 @@ class Amfora < Formula
   depends_on "go" => :build
   depends_on "make" => :build
 
+  head do
+    url 'https://github.com/makeworld-the-better-one/amfora.git'
+  end
   def install
 
     def applications
         share / 'applications'
     end
   
-    if not build.head?
+    if build.head?
+      system "git", "fetch", "--tags"
+    else
         # Install actual Makefile, not included in v1.5.0 source
     	system "curl", "-sSL", "https://github.com/makeworld-the-better-one/amfora/raw/b2b8e30/Makefile", "-o", "Makefile"
         ENV["VERSION"] = "v1.5.0"
@@ -26,7 +31,7 @@ class Amfora < Formula
     
     ENV["GO111MODULE"] = "on"
     ENV["BUILDER"] = "official-brew-tap"
-    system "gmake"
+    system "#{HOMEBREW_PREFIX}/bin/gmake"
     bin.install "amfora"
 
     if not OS.mac?


### PR DESCRIPTION
Hello,
in the end I think I got it figured out. The problem was that even specifing make as build dependency brew used the installed one linked with this weird shim `/usr/local/Homebrew/Library/Homebrew/shims/mac/super/gmake`.

On my Mac installation, make version is 3.81 which is too old for the shell assignment operator `!=` that (for some reasons) was silently not evaluated or evaluated empty.

Explicitely pointing the brew installed make (version 4-something) did the trick.

Also, as note in my gist here https://gist.github.com/Jackymancs4/83730fd42b96c9715ce1a09958a6d5f4/45476bb2fd71abf38d16e053b643390a8a5d790d replacing `var != ...` with `var := $(shell ...)` (which is the older way) made the whole process work.