### PR TITLE
Fix tests

### DIFF
--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -40,6 +40,6 @@ class Amfora < Formula
   end
 
   test do
-    assert_match /Amfora v#{version}\nCommit: .*\nBuilt by: official-brew-tap/, shell_output("#{bin}/amfora -v").chomp
+    assert_match /Amfora .*\nCommit: .*\nBuilt by: official-brew-tap/, shell_output("#{bin}/amfora -v").chomp
   end
 end

--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -40,6 +40,6 @@ class Amfora < Formula
   end
 
   test do
-    assert_equal shell_output("#{bin}/amfora -v").chomp, "Amfora v#{version}"
+    assert_match /Amfora v#{version}\nCommit: .*\nBuilt by: official-brew-tap/, shell_output("#{bin}/amfora -v").chomp
   end
 end


### PR DESCRIPTION
The current test always fails because it assumes that `amfora -v` returns only `Amfora vx.x.x`. That was the case with <1.4 I think.

Now I use a regex to check that Amfora, Commit and Built by are populated and the executable is present. It is less reliable (because I can't hard code the version) but works also on head.