### PR TITLE
Remove dependency from curl by using the appropriate brew component

### DIFF
--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -14,21 +14,28 @@ class Amfora < Formula
   head do
     url 'https://github.com/makeworld-the-better-one/amfora.git'
   end
+
+    # Can be removed in the future
+  resource 'temporary_makefile' do
+    url 'https://github.com/makeworld-the-better-one/amfora/raw/3cb15cb/Makefile'
+    sha256 '98784090b3338edd8fdc00c14b9878d9536c71649289eafde5e99e84dcbf81ff'
+  end
+
   def install
 
     def applications
         share / 'applications'
     end
-  
+
     if build.head?
       system "git", "fetch", "--tags"
     else
-        # Install actual Makefile, not included in v1.5.0 source
-    	system "curl", "-sSL", "https://github.com/makeworld-the-better-one/amfora/raw/3cb15cb/Makefile", "-o", "Makefile"
-        ENV["VERSION"] = "v1.5.0"
-        ENV["COMMIT"] = "922e7981a92cb7bf0d7b3baf1694d0fffe90d448"
+      # Install actual Makefile, not included in v1.5.0 source
+      resource('temporary_makefile').stage(buildpath)
+      ENV["VERSION"] = "v1.5.0"
+      ENV["COMMIT"] = "922e7981a92cb7bf0d7b3baf1694d0fffe90d448"
     end
-    
+
     ENV["GO111MODULE"] = "on"
     ENV["BUILDER"] = "official-brew-tap"
     system "#{HOMEBREW_PREFIX}/bin/gmake"


### PR DESCRIPTION
If you are not against it, this should close #1 end address #6 .
It remove dependency on curl so that (even if temporarily) nothing weird goes on. When the hack will be needed no more, just remove line 19-to-22 and line 34.

The code is fairly self-explainatory so that you can use it in the future as a snippet if the need emerges.

Tested with both head and normal.