### PR TITLE
Update for v1.7.1

### DIFF
--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -3,10 +3,10 @@
 class Amfora < Formula
   desc "A fancy terminal browser for the Gemini protocol."
   homepage "https://github.com/makeworld-the-better-one/amfora"
-  url "https://github.com/makeworld-the-better-one/amfora/archive/v1.6.0.tar.gz"
-  sha256 "a02b070679718953a4184ef2b7fbeccfcdf9bf227ca1efab34ee0d7fa21e9bd9"
+  url "https://github.com/makeworld-the-better-one/amfora/archive/v1.7.1.tar.gz"
+  sha256 "55a2d98e438ed3d41ad6bae6b4e04348a04e28a279fdc09866a1fdd5ee91d3ec"
   license "GPL-3.0"
-  version "1.6.0"
+  version "1.7.1"
 
   depends_on "go" => :build
   depends_on "make" => :build
@@ -25,8 +25,8 @@ class Amfora < Formula
       system "git", "fetch", "--tags"
       system "git", "fetch", "--unshallow"
     else
-      ENV["VERSION"] = "v1.6.0"
-      ENV["COMMIT"] = "445be96e467a959aff6dc8aaf75ca8751ce6f2d7"
+      ENV["VERSION"] = "v1.7.1"
+      ENV["COMMIT"] = "d7d7c3054e4822c418f1ca6ad119f6f05acfbea2"
     end
 
     ENV["GO111MODULE"] = "on"


### PR DESCRIPTION
It's my first time experience with updating brew formula, please check this PR carefully.
Still, I managed to successfully upgrade from v1.6.0 to v1.7.1 from my fork:
```shell
❯ brew upgrade sergetymo/homebrew-makeworlds-tap/amfora
```

Result:
```shell
❯ amfora -v
Amfora v1.7.1
Commit: d7d7c3054e4822c418f1ca6ad119f6f05acfbea2
Built by: official-brew-tap
```
Manually tested (on macOS 10.15.7) subscription functionality and basic browsing, everything seems working just fine.
As far as I understand, upgrading from your tap after merging this PR should work the same way.

Please do not hesitate to make necessary edits if needed.